### PR TITLE
Add riskType, entity, hopNum, and exposureType fields to RiskDetail in AML Risk Assessment Result

### DIFF
--- a/src/test/java/com/safeheron/demo/api/coin/CoinTest.java
+++ b/src/test/java/com/safeheron/demo/api/coin/CoinTest.java
@@ -1,9 +1,8 @@
 package com.safeheron.demo.api.coin;
 
-import com.safeheron.client.api.GasApiService;
+import com.safeheron.client.api.CoinApiService;
 import com.safeheron.client.config.SafeheronConfig;
-import com.safeheron.client.request.GasTransactionsGetByTxKeyRequest;
-import com.safeheron.client.response.GasTransactionsGetByTxKeyResponse;
+import com.safeheron.client.response.CoinResponse;
 import com.safeheron.client.utils.ServiceCreator;
 import com.safeheron.client.utils.ServiceExecutor;
 import org.junit.BeforeClass;
@@ -14,30 +13,15 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 
 public class CoinTest {
 
 
-    static GasApiService gasApiService;
+    static CoinApiService coinApiService;
 
     static Map<String, Object> config;
-
-//    @BeforeClass
-//    public static void beforeClass() throws FileNotFoundException {
-//        Yaml yaml = new Yaml();
-//        File file = new File("src/test/resources/demo/api/coin/config.yaml");
-//        InputStream inputStream = new FileInputStream(file);
-//        config = yaml.load(inputStream);
-//
-//        coinApiService = ServiceCreator.create(CoinApiService.class, SafeheronConfig.builder()
-//                .baseUrl(config.get("baseUrl").toString())
-//                .apiKey(config.get("apiKey").toString())
-//                .safeheronRsaPublicKey(config.get("safeheronPublicKey").toString())
-//                .rsaPrivateKey(config.get("privateKey").toString())
-//                .requestTimeout(Long.valueOf(config.get("requestTimeout").toString()))
-//                .build());
-//    }
 
     @BeforeClass
     public static void beforeClass() throws FileNotFoundException {
@@ -46,7 +30,7 @@ public class CoinTest {
         InputStream inputStream = new FileInputStream(file);
         config = yaml.load(inputStream);
 
-        gasApiService = ServiceCreator.create(GasApiService.class, SafeheronConfig.builder()
+        coinApiService = ServiceCreator.create(CoinApiService.class, SafeheronConfig.builder()
                 .baseUrl(config.get("baseUrl").toString())
                 .apiKey(config.get("apiKey").toString())
                 .safeheronRsaPublicKey(config.get("safeheronPublicKey").toString())
@@ -57,12 +41,8 @@ public class CoinTest {
 
     @Test
     public void testCreateAccountAndAddCoin(){
-//        GasStatusResponse execute = ServiceExecutor.execute(gasApiService.gasStatus());
-//        System.out.println(execute);
-        GasTransactionsGetByTxKeyRequest gasTransactionsGetByTxKeyRequest = new GasTransactionsGetByTxKeyRequest();
-        gasTransactionsGetByTxKeyRequest.setTxKey("xx");
-        GasTransactionsGetByTxKeyResponse execute1 = ServiceExecutor.execute(gasApiService.gasTransactionsGetByTxKey(gasTransactionsGetByTxKeyRequest));
-        System.out.println(execute1);
+        List<CoinResponse> execute = ServiceExecutor.execute(coinApiService.listCoin());
+        System.out.println(execute);
     }
 
 


### PR DESCRIPTION
Added four new fields to `com.safeheron.client.response.RiskDetail` in the AML risk assessment result:
* riskType
* entity
* hopNum
* exposureType

These fields provide more context in the risk details and are fully backward-compatible.